### PR TITLE
[OpenVINO backend] OpenVINOQuantizer

### DIFF
--- a/backends/openvino/__init__.py
+++ b/backends/openvino/__init__.py
@@ -1,4 +1,5 @@
 from .partitioner import OpenvinoPartitioner
 from .preprocess import OpenvinoBackend
+from .quantizer.quantizer import OpenVINOQuantizer
 
-__all__ = [OpenvinoBackend, OpenvinoPartitioner] 
+__all__ = [OpenvinoBackend, OpenvinoPartitioner, OpenVINOQuantizer] 

--- a/backends/openvino/quantizer/__init__.py
+++ b/backends/openvino/quantizer/__init__.py
@@ -1,0 +1,3 @@
+from .quantizer import OpenVINOQuantizer
+
+__all__ = [OpenVINOQuantizer]

--- a/backends/openvino/quantizer/quantizer.py
+++ b/backends/openvino/quantizer/quantizer.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch.fx
 from torch.ao.quantization.observer import HistogramObserver
 from torch.ao.quantization.observer import PerChannelMinMaxObserver
+from torch.ao.quantization.observer import MinMaxObserver
 from torch.ao.quantization.quantizer.quantizer import EdgeOrNode
 from torch.ao.quantization.quantizer.quantizer import QuantizationAnnotation
 from torch.ao.quantization.quantizer.quantizer import QuantizationSpec
@@ -276,6 +277,7 @@ class OpenVINOQuantizer(Quantizer):
                 torch.per_tensor_symmetric if qconfig.mode is QuantizationScheme.SYMMETRIC else torch.per_tensor_affine
             )
         if is_weight:
+            observer = PerChannelMinMaxObserver if qconfig.per_channel else MinMaxObserver
             observer = PerChannelMinMaxObserver
             quant_min = -128
             quant_max = 127

--- a/backends/openvino/quantizer/quantizer.py
+++ b/backends/openvino/quantizer/quantizer.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2025 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch.fx
+from torch.ao.quantization.observer import HistogramObserver
+from torch.ao.quantization.observer import PerChannelMinMaxObserver
+from torch.ao.quantization.quantizer.quantizer import EdgeOrNode
+from torch.ao.quantization.quantizer.quantizer import QuantizationAnnotation
+from torch.ao.quantization.quantizer.quantizer import QuantizationSpec
+from torch.ao.quantization.quantizer.quantizer import QuantizationSpecBase
+from torch.ao.quantization.quantizer.quantizer import Quantizer
+from torch.ao.quantization.quantizer.quantizer import SharedQuantizationSpec
+
+import nncf
+from nncf.common.graph.graph import NNCFGraph
+from nncf.common.logging import nncf_logger
+from nncf.common.quantization.quantizer_propagation.solver import QuantizerPropagationRule
+from nncf.common.quantization.quantizer_setup import QuantizationPointBase
+from nncf.common.quantization.quantizer_setup import SingleConfigQuantizerSetup
+from nncf.common.quantization.structs import QuantizationPreset
+from nncf.common.quantization.structs import QuantizationScheme
+from nncf.experimental.torch.fx.nncf_graph_builder import GraphConverter
+from nncf.experimental.torch.fx.node_utils import get_graph_node_by_name
+from nncf.experimental.torch.fx.transformations import fold_constant_except_qdq
+from nncf.parameters import ModelType
+from nncf.parameters import QuantizationMode
+from nncf.parameters import TargetDevice
+from nncf.quantization.advanced_parameters import FP8QuantizationParameters
+from nncf.quantization.advanced_parameters import OverflowFix
+from nncf.quantization.advanced_parameters import QuantizationParameters
+from nncf.quantization.algorithms.min_max.algorithm import MinMaxQuantization
+from nncf.scopes import IgnoredScope
+from nncf.torch.model_graph_manager import get_weight_tensor_port_ids
+
+QUANT_ANNOTATION_KEY = "quantization_annotation"
+
+
+class OpenVINOQuantizer(Quantizer):
+    """
+    Implementation of the Torch AO quantizer which annotates models with quantization annotations
+    optimally for the inference via OpenVINO.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: Optional[QuantizationMode] = None,
+        preset: Optional[QuantizationPreset] = None,
+        target_device: TargetDevice = TargetDevice.ANY,
+        model_type: Optional[ModelType] = None,
+        ignored_scope: Optional[IgnoredScope] = None,
+        overflow_fix: Optional[OverflowFix] = None,
+        quantize_outputs: bool = False,
+        activations_quantization_params: Optional[Union[QuantizationParameters, FP8QuantizationParameters]] = None,
+        weights_quantization_params: Optional[Union[QuantizationParameters, FP8QuantizationParameters]] = None,
+        quantizer_propagation_rule: QuantizerPropagationRule = QuantizerPropagationRule.MERGE_ALL_IN_ONE,
+    ):
+        """
+        :param mode: Defines optimization mode for the algorithm. None by default.
+        :param preset: A preset controls the quantization mode (symmetric and asymmetric).
+            It can take the following values:
+            - `performance`: Symmetric quantization of weights and activations.
+            - `mixed`: Symmetric quantization of weights and asymmetric quantization of activations.
+            Default value is None. In this case, `mixed` preset is used for `transformer`
+            model type otherwise `performance`.
+        :param target_device: A target device the specificity of which will be taken
+            into account while compressing in order to obtain the best performance
+            for this type of device, defaults to TargetDevice.ANY.
+        :param model_type: Model type is needed to specify additional patterns
+            in the model. Supported only `transformer` now.
+        :param ignored_scope: An ignored scope that defined the list of model control
+            flow graph nodes to be ignored during quantization.
+        :param overflow_fix: This option controls whether to apply the overflow issue
+            fix for the 8-bit quantization.
+        :param quantize_outputs: Whether to insert additional quantizers right before
+            each of the model outputs.
+        :param activations_quantization_params: Quantization parameters for model
+            activations.
+        :param weights_quantization_params: Quantization parameters for model weights.
+        :param quantizer_propagation_rule: The strategy to be used while propagating and merging quantizers.
+        MERGE_ALL_IN_ONE by default.
+        """
+        self._min_max_algo = MinMaxQuantization(
+            mode=mode,
+            preset=preset,
+            target_device=target_device,
+            model_type=model_type,
+            ignored_scope=ignored_scope,
+            overflow_fix=overflow_fix,
+            quantize_outputs=quantize_outputs,
+            activations_quantization_params=activations_quantization_params,
+            weights_quantization_params=weights_quantization_params,
+            quantizer_propagation_rule=quantizer_propagation_rule,
+        )
+
+    def get_quantization_setup(self, model: torch.fx.GraphModule, nncf_graph: NNCFGraph) -> SingleConfigQuantizerSetup:
+        self._min_max_algo._set_backend_entity(model)
+        return self._min_max_algo.find_quantization_setup(model, nncf_graph)
+
+    def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+        nncf_graph = GraphConverter.create_nncf_graph(model)
+        quantization_setup = self.get_quantization_setup(model, nncf_graph)
+
+        graph = model.graph
+        node_vs_torch_annotation = defaultdict(QuantizationAnnotation)
+
+        for qp in quantization_setup.quantization_points.values():
+            edge_or_node, annotation = self._get_edge_or_node_and_annotation(
+                graph, nncf_graph, qp, node_vs_torch_annotation
+            )
+            qspec = self._get_torch_ao_qspec_from_qp(qp)
+            self._fill_torch_ao_annotation(edge_or_node, qspec, annotation)
+
+        for quantizer_ids in quantization_setup.unified_scale_groups.values():
+
+            root_quantizer_id = self._get_unified_scales_root_quantizer_id(
+                nncf_graph, quantizer_ids, quantization_setup
+            )
+            root_qp = quantization_setup.quantization_points[root_quantizer_id]
+
+            if any(root_qp.qconfig != quantization_setup.quantization_points[q_id].qconfig for q_id in quantizer_ids):
+                qps = [quantization_setup.quantization_points[q_id] for q_id in quantizer_ids]
+                msg = (
+                    "Different quantization configs are set to one unified scale group:"
+                    f"{[(qp.insertion_point.__dict__, str(qp.qconfig)) for qp in qps]}"
+                )
+                raise nncf.InternalError(msg)
+
+            root_target_node = get_graph_node_by_name(graph, root_qp.insertion_point.target_node_name)
+            root_edge_or_node = self._get_edge_or_node(root_target_node, root_qp, nncf_graph)
+
+            for quantizer_id in quantizer_ids:
+                if quantizer_id == root_quantizer_id:
+                    continue
+
+                qspec = SharedQuantizationSpec(root_edge_or_node)
+                qp = quantization_setup.quantization_points[quantizer_id]
+                edge_or_node, annotation = self._get_edge_or_node_and_annotation(
+                    graph, nncf_graph, qp, node_vs_torch_annotation
+                )
+                self._fill_torch_ao_annotation(edge_or_node, qspec, annotation)
+
+        for node, annotation in node_vs_torch_annotation.items():
+            assert QUANT_ANNOTATION_KEY not in node.meta
+            node.meta[QUANT_ANNOTATION_KEY] = annotation
+
+    @staticmethod
+    def _get_unified_scales_root_quantizer_id(
+        nncf_graph: NNCFGraph, quantizer_ids: List[int], quantizer_setup: SingleConfigQuantizerSetup
+    ) -> int:
+        """
+        Identifies the earliest quantizer node ID based on the corresponding `nncf_node.node_id`
+        in the given NNCFGraph. This is required by the `_get_obs_or_fq_map` function.
+        Refer to: https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/pt2e/prepare.py#L291
+
+        :param nncf_graph: The NNCFGraph instance.
+        :param quantizer_ids: The list of quantizer IDs to evaluate.
+        :param quantizer_setup: The instance of SingleConfigQuantizerSetup.
+        :return: The ID of the earliest quantizer node in terms of `nncf_node.node_id`.
+        """
+        nncf_node_quantizer_id = None
+        root_quantizer_id = None
+        for quantizer_id in quantizer_ids:
+            target_node_name = quantizer_setup.quantization_points[quantizer_id].insertion_point.target_node_name
+            nncf_node = nncf_graph.get_node_by_name(target_node_name)
+            if nncf_node_quantizer_id is None or nncf_node.node_id < nncf_node_quantizer_id:
+                root_quantizer_id = quantizer_id
+                nncf_node_quantizer_id = nncf_node.node_id
+        return root_quantizer_id
+
+    @staticmethod
+    def _get_edge_or_node_and_annotation(
+        graph: torch.fx.Graph,
+        nncf_graph: NNCFGraph,
+        qp: QuantizationPointBase,
+        node_vs_torch_annotation: Dict[torch.fx.Node, QuantizationAnnotation],
+    ) -> Tuple[EdgeOrNode, QuantizationAnnotation]:
+        """
+        Retrieves the edge or node and its corresponding QuantizationAnnotation based on the given graph,
+        quantization point, and node-to-annotation mapping.
+
+        :param graph: torch.fx.Graph instance.
+        :param nncf_graph: NNCFGraph instance.
+        :param qp: QuantizationPointBase instance.
+        :param node_vs_torch_annotation: A dictionary mapping torch.fx.GraphNode objects to their respective
+            QuantizationAnnotations.
+        :return: A tuple containing the EdgeOrNode and its associated QuantizationAnnotation.
+        """
+        target_node = get_graph_node_by_name(graph, qp.insertion_point.target_node_name)
+        annotation = node_vs_torch_annotation[target_node]
+        edge_or_node = OpenVINOQuantizer._get_edge_or_node(target_node, qp, nncf_graph)
+        return edge_or_node, annotation
+
+    @staticmethod
+    def _get_edge_or_node(target_node: torch.fx.Node, qp: QuantizationPointBase, nncf_graph: NNCFGraph) -> EdgeOrNode:
+        """
+        Returns the edge or node based on the given target node and quantization point.
+
+        :param target_node: Target node instance.
+        :param qp: QuantizationPointBase instance.
+        :param graph: NNCFGraph instance.
+        :return: The corresponding EdgeOrNode derived from the target node and quantization point.
+        """
+        ip = qp.insertion_point
+        if qp.is_weight_quantization_point():
+            nncf_node = nncf_graph.get_node_by_name(target_node.name)
+            weights_ports_ids = get_weight_tensor_port_ids(nncf_node, nncf_graph)
+            if len(weights_ports_ids) > 1:
+                # TODO(dlyakhov): support quantization for nodes with several weights
+                nncf_logger.warning(
+                    f"Quantization of the weighted node {target_node.name}"
+                    " is not yet supported by the OpenVINOQuantizer."
+                    f" Only the weight on port ID {weights_ports_ids[0]} will be quantized."
+                    f" Quantizable weights are located on ports: {weights_ports_ids}."
+                )
+            weight_node = target_node.all_input_nodes[weights_ports_ids[0]]
+            return (weight_node, target_node)
+
+        if ip.input_port_id is None:
+            return target_node
+
+        node = target_node.all_input_nodes[ip.input_port_id]
+        return (node, target_node)
+
+    @staticmethod
+    def _fill_torch_ao_annotation(
+        edge_or_node: EdgeOrNode,
+        qspec: QuantizationSpecBase,
+        annotation_to_update: QuantizationAnnotation,
+    ) -> None:
+        """
+        Helper method to update the annotation_to_update based on the specified edge_or_node and qspec.
+
+        :param edge_or_node: The target EdgeOrNode to be used for the update.
+        :param qspec: An instance of QuantizationSpecBase representing the quantization specification to apply.
+        :param annotation_to_update: The annotation to update based on the edge_or_node and qspec.
+        """
+        if isinstance(edge_or_node, torch.fx.Node):
+            annotation_to_update.output_qspec = qspec
+        else:
+            annotation_to_update.input_qspec_map[edge_or_node[0]] = qspec
+
+    @staticmethod
+    def _get_torch_ao_qspec_from_qp(qp: QuantizationPointBase) -> QuantizationSpec:
+        """
+        Retrieves the quantization configuration from the given quantization point and
+        converts it into a QuantizationSpec.
+
+        :param qp: An instance of QuantizationPointBase.
+        :return: A QuantizationSpec retrieved and converted from the quantization point.
+        """
+        # Eps value is copied from nncf/torch/quantization/layers.py
+        extra_args = {"eps": 1e-16}
+        qconfig = qp.qconfig
+        is_weight = qp.is_weight_quantization_point()
+
+        if qconfig.per_channel:
+            torch_qscheme = (
+                torch.per_channel_symmetric
+                if qconfig.mode is QuantizationScheme.SYMMETRIC
+                else torch.per_channel_affine
+            )
+        else:
+            torch_qscheme = (
+                torch.per_tensor_symmetric if qconfig.mode is QuantizationScheme.SYMMETRIC else torch.per_tensor_affine
+            )
+        if is_weight:
+            observer = PerChannelMinMaxObserver
+            quant_min = -128
+            quant_max = 127
+            dtype = torch.int8
+            channel_axis = 0
+        else:
+            observer = (
+                HistogramObserver
+                if torch_qscheme in [torch.per_tensor_symmetric, torch.per_tensor_affine]
+                else PerChannelMinMaxObserver
+            )
+            quant_min = 0
+            quant_max = 255
+            dtype = torch.int8 if qconfig.signedness_to_force else torch.uint8
+            channel_axis = 1  # channel dim for activations
+        return QuantizationSpec(
+            dtype=dtype,
+            observer_or_fake_quant_ctr=observer.with_args(**extra_args),
+            quant_min=quant_min,
+            quant_max=quant_max,
+            qscheme=torch_qscheme,
+            ch_axis=channel_axis,
+            is_dynamic=False,
+        )
+
+    def validate(self, model: torch.fx.GraphModule) -> None:
+        pass
+
+    def transform_for_annotation(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+        fold_constant_except_qdq(model)
+        return model

--- a/backends/openvino/quantizer/quantizer.py
+++ b/backends/openvino/quantizer/quantizer.py
@@ -1,13 +1,8 @@
-# Copyright (c) 2025 Intel Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#      http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) Intel Corporation
+#
+# Licensed under the BSD License (the "License"); you may not use this file
+# except in compliance with the License. See the license file in the root
+# directory of this source tree for more details.
 
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple

--- a/backends/openvino/requirements.txt
+++ b/backends/openvino/requirements.txt
@@ -6,3 +6,4 @@ tokenizers
 transformers
 piq
 pillow
+nncf @ https://github.com/openvinotoolkit/nncf.git

--- a/examples/openvino/CMakeLists.txt
+++ b/examples/openvino/CMakeLists.txt
@@ -55,6 +55,7 @@ target_include_directories(openvino_portable_ops_lib PUBLIC ${_common_include_di
 
 # Build Executor Runner
 add_executable(openvino_executor_runner ${_openvino_executor_runner__srcs})
+
 target_include_directories(
   openvino_executor_runner PUBLIC ${_common_include_directories} ${EXECUTORCH_ROOT}/cmake-openvino-out/third-party/gflags/include
 )

--- a/examples/openvino/aot/README.md
+++ b/examples/openvino/aot/README.md
@@ -31,9 +31,16 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
   - `[1, 3, 224, 224]` (Zsh users: wrap in quotes)
   - `(1, 3, 224, 224)`
 
+- **`--quantize`** (optional):
+  Enable model quantization: Default is False.
+
+- **`--dataset`** (optional):
+  Path to the calibration dataset. TODO: It is necessary to think in what form to support the dataset. For the experiment, tiny-imagenet is used, which can be downloaded from here http://cs231n.stanford.edu/tiny-imagenet-200.zip and specify the path to it. 
+
 - **`--device`** (optional):  
   Target device for the compiled model. Default is `CPU`.  
   Examples: `CPU`, `GPU`
+
 
 ## **Examples**
 

--- a/examples/openvino/aot/README.md
+++ b/examples/openvino/aot/README.md
@@ -16,7 +16,7 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
   Supported values:
   - `timm` (e.g., VGG16, ResNet50)
   - `torchvision` (e.g., resnet18, mobilenet_v2)
-  - `huggingface` (e.g., bert-base-uncased)
+  - `huggingface` (e.g., bert-base-uncased). NB: Quantization and validation is not supported yet.
 
 - **`--model`** (required):
   Name of the model to export.
@@ -36,10 +36,12 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
   The dataset length must be evenly divisible by the batch size.
 
 - **`--quantize`** (optional):
-  Enable model quantization: Default is False.
+  Enable model quantization. --dataset argument is requred for the quantization. `huggingface` suite  does not supported yet.
 
-- **`--quantize`** (optional):
-  Enable model validation. --dataset argument is requred for the validation.
+
+- **`--validate`** (optional):
+  Enable model validation. --dataset argument is requred for the validation. `huggingface` suite does not supported yet.
+
 
 - **`--dataset`** (optional):
   Path to the imagenet-like calibration dataset.

--- a/examples/openvino/aot/README.md
+++ b/examples/openvino/aot/README.md
@@ -11,34 +11,41 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
 ```
 
 ### **Arguments**
-- **`--suite`** (required):  
-  Specifies the model suite to use.  
+- **`--suite`** (required):
+  Specifies the model suite to use.
   Supported values:
   - `timm` (e.g., VGG16, ResNet50)
   - `torchvision` (e.g., resnet18, mobilenet_v2)
   - `huggingface` (e.g., bert-base-uncased)
 
-- **`--model`** (required):  
-  Name of the model to export.  
+- **`--model`** (required):
+  Name of the model to export.
   Examples:
   - For `timm`: `vgg16`, `resnet50`
   - For `torchvision`: `resnet18`, `mobilenet_v2`
   - For `huggingface`: `bert-base-uncased`, `distilbert-base-uncased`
 
-- **`--input_shape`** (required):  
-  Input shape for the model. Provide this as a **list** or **tuple**.  
+- **`--input_shape`**:
+  Input shape for the model. Provide this as a **list** or **tuple**.
   Examples:
   - `[1, 3, 224, 224]` (Zsh users: wrap in quotes)
   - `(1, 3, 224, 224)`
 
+- **`--batch_size`** :
+  Batch size for the validation. Default batch_size == 1.
+  The dataset length must be evenly divisible by the batch size.
+
 - **`--quantize`** (optional):
   Enable model quantization: Default is False.
 
-- **`--dataset`** (optional):
-  Path to the calibration dataset. TODO: It is necessary to think in what form to support the dataset. For the experiment, tiny-imagenet is used, which can be downloaded from here http://cs231n.stanford.edu/tiny-imagenet-200.zip and specify the path to it. 
+- **`--quantize`** (optional):
+  Enable model validation. --dataset argument is requred for the validation.
 
-- **`--device`** (optional):  
-  Target device for the compiled model. Default is `CPU`.  
+- **`--dataset`** (optional):
+  Path to the imagenet-like calibration dataset.
+
+- **`--device`** (optional)
+  Target device for the compiled model. Default is `CPU`.
   Examples: `CPU`, `GPU`
 
 
@@ -58,22 +65,31 @@ python aot_openvino_compiler.py --suite torchvision --model resnet50 --input_sha
 ```bash
 python aot_openvino_compiler.py --suite huggingface --model bert-base-uncased --input_shape "(1, 512)" --device CPU
 ```
+### Export and validate TIMM Resnet50d model for the CPU
+```bash
+python aot_openvino_compiler.py --suite timm --model vgg16 --input_shape [1, 3, 224, 224] --device CPU --validate --dataset /path/to/dataset
+```
+
+### Export, quantize and validate TIMM Resnet50d model for the CPU
+```bash
+python aot_openvino_compiler.py --suite timm --model vgg16 --input_shape [1, 3, 224, 224] --device CPU --validate --dataset /path/to/dataset --quantize
+```
 
 ## **Notes**
-1. **Input Shape in Zsh**:  
+1. **Input Shape in Zsh**:
    If you are using Zsh, wrap `--input_shape` in quotes or use a tuple:
    ```bash
    --input_shape '[1, 3, 224, 224]'
    --input_shape "(1, 3, 224, 224)"
    ```
 
-2. **Model Compatibility**:  
+2. **Model Compatibility**:
    Ensure the specified `model_name` exists in the selected `suite`. Use the corresponding library's documentation to verify model availability.
 
-3. **Output File**:  
+3. **Output File**:
    The exported model will be saved as `<MODEL_NAME>.pte` in the current directory.
 
-4. **Dependencies**:  
+4. **Dependencies**:
    - Python 3.8+
    - PyTorch
    - Executorch
@@ -82,14 +98,14 @@ python aot_openvino_compiler.py --suite huggingface --model bert-base-uncased --
    - Transformers (`pip install transformers`)
 
 ## **Error Handling**
-- **Model Not Found**:  
+- **Model Not Found**:
   If the script raises an error such as:
   ```bash
   ValueError: Model <MODEL_NAME> not found
   ```
   Verify that the model name is correct for the chosen suite.
 
-- **Unsupported Input Shape**:  
+- **Unsupported Input Shape**:
   Ensure `--input_shape` is provided as a valid list or tuple.
 
 

--- a/examples/openvino/aot/README.md
+++ b/examples/openvino/aot/README.md
@@ -25,7 +25,7 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
   - For `torchvision`: `resnet18`, `mobilenet_v2`
   - For `huggingface`: `bert-base-uncased`, `distilbert-base-uncased`
 
-- **`--input_shape`**:
+- **`--input_shape`**(optional):
   Input shape for the model. Provide this as a **list** or **tuple**.
   Examples:
   - `[1, 3, 224, 224]` (Zsh users: wrap in quotes)
@@ -38,10 +38,14 @@ python aot_openvino_compiler.py --suite <MODEL_SUITE> --model <MODEL_NAME> --inp
 - **`--quantize`** (optional):
   Enable model quantization. --dataset argument is requred for the quantization. `huggingface` suite  does not supported yet.
 
+- **`--quantization_flow`** (optional):
+  Specifies the way to quantize torch.fx.GraphModule.
+  Supported values:
+  - `nncf`: `nncf quantize_pt2e` API (default)
+  - `pt2e`: torch ao quantization pipeline.
 
 - **`--validate`** (optional):
   Enable model validation. --dataset argument is requred for the validation. `huggingface` suite does not supported yet.
-
 
 - **`--dataset`** (optional):
   Path to the imagenet-like calibration dataset.

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -4,10 +4,15 @@
 # except in compliance with the License. See the license file in the root
 # directory of this source tree for more details.
 
+import nncf.experimental
+import nncf.experimental.torch
 import executorch
+import nncf
 import timm
 import torch
+import torchvision.datasets as datasets
 import torchvision.models as torchvision_models
+import torchvision.transforms as transforms
 from transformers import AutoModel
 from executorch.exir.backend.backend_details import CompileSpec
 from executorch.backends.openvino.preprocess import OpenvinoBackend
@@ -16,6 +21,12 @@ from executorch.exir import EdgeProgramManager, to_edge
 from torch.export import export, ExportedProgram
 from torch.export.exported_program import ExportedProgram
 import argparse
+from executorch.backends.openvino import OpenVINOQuantizer
+from torch.ao.quantization.quantize_pt2e import (
+    convert_pt2e,
+    prepare_pt2e,
+)
+
 
 # Function to load a model based on the selected suite
 def load_model(suite: str, model_name: str):
@@ -30,7 +41,48 @@ def load_model(suite: str, model_name: str):
     else:
         raise ValueError(f"Unsupported model suite: {suite}")
 
-def main(suite: str, model_name: str, input_shape, device: str):
+
+def load_calibration_dataset(dataset_path: str):
+    val_dir = f"{dataset_path}/val"
+
+    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+
+    val_dataset = datasets.ImageFolder(
+        val_dir,
+        transforms.Compose(
+            [
+                transforms.Resize(64), # for tiny imagenet
+                transforms.ToTensor(),
+                normalize,
+            ]
+        ),
+    )
+
+    calibration_dataset = torch.utils.data.DataLoader(
+        val_dataset, batch_size=1, shuffle=False, num_workers=0, pin_memory=True
+    )
+
+    return calibration_dataset
+
+
+def quantize_model(model: torch.fx.GraphModule, calibration_dataset: torch.utils.data.DataLoader, subset_size=300):
+    quantizer = OpenVINOQuantizer()
+
+    print("PTQ: Annotate the model...")
+    annotated_model = prepare_pt2e(model, quantizer)
+    
+    print("PTQ: Calibrate the model...")
+    for idx, data in enumerate(calibration_dataset):
+        if idx >= subset_size:
+            break
+        annotated_model(data[0])
+
+    print("PTQ: Convert the quantized model...")
+    quantized_model = convert_pt2e(annotated_model)
+    return quantized_model
+
+
+def main(suite: str, model_name: str, input_shape, quantize: bool, dataset_path: str, device: str):
     # Ensure input_shape is a tuple
     if isinstance(input_shape, list):
         input_shape = tuple(input_shape)
@@ -44,8 +96,18 @@ def main(suite: str, model_name: str, input_shape, device: str):
     # Provide input
     example_args = (torch.randn(*input_shape), )
 
-    # Export to aten dialect using torch.export
+    # Export the model to the aten dialect
     aten_dialect: ExportedProgram = export(model, example_args)
+
+    if quantize:
+        # Quantize model
+        if not dataset_path:
+            raise ValueError("Quantization requires a calibration dataset.")
+        calibration_dataset = load_calibration_dataset(dataset_path)
+
+        captured_model = aten_dialect.module()
+        quantized_model = quantize_model(captured_model, calibration_dataset)
+        aten_dialect: ExportedProgram = export(quantized_model, example_args)
 
     # Convert to edge dialect
     edge_program: EdgeProgramManager = to_edge(aten_dialect)
@@ -71,10 +133,13 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, required=True, help="Model name to be loaded.")
     parser.add_argument("--input_shape", type=eval, required=True,
                         help="Input shape for the model as a list or tuple (e.g., [1, 3, 224, 224] or (1, 3, 224, 224)).")
+    parser.add_argument("--quantize", action="store_true", help="Enable model quantization.")
+    parser.add_argument("--dataset", type=str, help="Path to the calibration dataset.")
     parser.add_argument("--device", type=str, default="CPU",
                         help="Target device for compiling the model (e.g., CPU, GPU). Default is CPU.")
 
     args = parser.parse_args()
 
     # Run the main function with parsed arguments
-    main(args.suite, args.model, args.input_shape, args.device)
+    with nncf.torch.disable_patching():
+        main(args.suite, args.model, args.input_shape, args.quantize, args.dataset, args.device)

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -66,7 +66,8 @@ def load_calibration_dataset(dataset_path: str):
 
 
 def quantize_model(model: torch.fx.GraphModule, example_args, subset_size=300):
-    quantizer = OpenVINOQuantizer(ignored_scope=nncf.IgnoredScope(types=["__getitem__", "layer_norm"]))
+    #quantizer = OpenVINOQuantizer(ignored_scope=nncf.IgnoredScope(types=["__getitem__", "layer_norm"]))
+    quantizer = OpenVINOQuantizer()
 
     print("PTQ: Annotate the model...")
     annotated_model = prepare_pt2e(model, quantizer)
@@ -100,12 +101,12 @@ def main(suite: str, model_name: str, input_shape, quantize: bool, dataset_path:
         # Quantize model
         if not dataset_path:
             raise ValueError("Quantization requires a calibration dataset.")
-        calibration_dataset = load_calibration_dataset(dataset_path)
+        #calibration_dataset = load_calibration_dataset(dataset_path)
 
         captured_model = aten_dialect.module()
-        visualize_fx_model(captured_model, f"{model_name}_fp32.svg")
+        #visualize_fx_model(captured_model, f"{model_name}_fp32.svg")
         quantized_model = quantize_model(captured_model, example_args)
-        visualize_fx_model(quantized_model, f"{model_name}_int8.svg")
+        #visualize_fx_model(quantized_model, f"{model_name}_int8.svg")
         aten_dialect: ExportedProgram = export(quantized_model, example_args)
 
     # Convert to edge dialect

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -4,33 +4,31 @@
 # except in compliance with the License. See the license file in the root
 # directory of this source tree for more details.
 
-import nncf.experimental
-import nncf.experimental.torch
+import argparse
+
 import executorch
-import nncf
 import timm
 import torch
 import torchvision.datasets as datasets
 import torchvision.models as torchvision_models
-import torchvision.transforms as transforms
-from transformers import AutoModel
-from executorch.exir.backend.backend_details import CompileSpec
-from executorch.backends.openvino.preprocess import OpenvinoBackend
-from executorch.backends.openvino.partitioner import OpenvinoPartitioner
-from executorch.exir import EdgeProgramManager, to_edge
-from torch.export import export, ExportedProgram
-from torch.export.exported_program import ExportedProgram
-import argparse
 from executorch.backends.openvino import OpenVINOQuantizer
-#from nncf.experimental.torch.fx.quantization.quantizer.openvino_quantizer import OpenVINOQuantizer
-from nncf.experimental.torch.fx.quantization.quantize_pt2e import quantize_pt2e
-from torch.ao.quantization.quantize_pt2e import (
-    convert_pt2e,
-    prepare_pt2e,
-)
+from executorch.backends.openvino.partitioner import OpenvinoPartitioner
+from executorch.exir import EdgeProgramManager
+from executorch.exir import to_edge
+from executorch.exir.backend.backend_details import CompileSpec
 from sklearn.metrics import accuracy_score
 from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
+from torch.export import ExportedProgram
+from torch.export import export
+from torch.export.exported_program import ExportedProgram
+from transformers import AutoModel
+
+import nncf
+import nncf.experimental
+import nncf.experimental.torch
+from nncf.experimental.torch.fx.quantization.quantize_pt2e import quantize_pt2e
+
 
 # Function to load a model based on the selected suite
 def load_model(suite: str, model_name: str):
@@ -54,10 +52,7 @@ def load_calibration_dataset(dataset_path: str, suite: str, model: torch.nn.Modu
     else:
         transform = create_transform(**resolve_data_config(model.pretrained_cfg, model=model))
 
-    val_dataset = datasets.ImageFolder(
-        val_dir,
-        transform=transform
-    )
+    val_dataset = datasets.ImageFolder(val_dir, transform=transform)
 
     calibration_dataset = torch.utils.data.DataLoader(
         val_dataset, batch_size=1, shuffle=False, num_workers=0, pin_memory=True
@@ -78,7 +73,7 @@ def main(suite: str, model_name: str, input_shape, quantize: bool, dataset_path:
     model = model.eval()
 
     # Provide input
-    example_args = (torch.randn(*input_shape), )
+    example_args = (torch.randn(*input_shape),)
 
     # Export the model to the aten dialect
     aten_dialect: ExportedProgram = export(model, example_args)
@@ -93,14 +88,19 @@ def main(suite: str, model_name: str, input_shape, quantize: bool, dataset_path:
         calibration_dataset = load_calibration_dataset(dataset_path, suite, model)
 
         captured_model = aten_dialect.module()
-        #visualize_fx_model(captured_model, f"{model_name}_fp32.svg")
         quantizer = OpenVINOQuantizer()
 
         print("PTQ: Quantize the model")
+
         def transform(x):
             return x[0]
 
-        quantized_model = quantize_pt2e(captured_model, quantizer, calibration_dataset=nncf.Dataset(calibration_dataset, transform_func=transform), fold_quantize=False)
+        quantized_model = quantize_pt2e(
+            captured_model,
+            quantizer,
+            calibration_dataset=nncf.Dataset(calibration_dataset, transform_func=transform),
+            fold_quantize=False,
+        )
 
         aten_dialect: ExportedProgram = export(quantized_model, example_args)
 
@@ -154,69 +154,53 @@ def main(suite: str, model_name: str, input_shape, quantize: bool, dataset_path:
         # 2: Run the executor
         print("Run openvino_executor_runner...")
         import subprocess
-        breakpoint()
-        subprocess.run(["../../../cmake-openvino-out/examples/openvino/openvino_executor_runner",
-                    f"--model_path={model_name}",
-                    f"--input_list_path={inp_list_file}",
-                    f"--output_folder_path={out_path}",
-                    #f"--num_iter={len(input_files)}"
-        ])
+
+        subprocess.run(
+            [
+                "../../../cmake-openvino-out/examples/openvino/openvino_executor_runner",
+                f"--model_path={model_name}",
+                f"--input_list_path={inp_list_file}",
+                f"--output_folder_path={out_path}",
+                # f"--num_iter={len(input_files)}"
+            ]
+        )
 
         # 3: load the outputs and compare with the targets
         import numpy as np
+
         predictions = []
         for i in range(len(input_files)):
-            predictions.append(
-                np.fromfile(
-                    os.path.join(out_path, f"output_{i}.raw"), dtype=np.float32
-                )
-            )
+            predictions.append(np.fromfile(os.path.join(out_path, f"output_{i}.raw"), dtype=np.float32))
 
-        k_val = [1, 5]
         acc_top1 = accuracy_score(predictions, targets)
         print(f"acc@1: {acc_top1}")
 
 
-from torch.fx.passes.graph_drawer import FxGraphDrawer
-def visualize_fx_model(model: torch.fx.GraphModule, output_svg_path: str):
-    g = FxGraphDrawer(model, output_svg_path)
-    g.get_dot_graph().write_svg(output_svg_path)
-
-def generate_inputs(dest_path: str, file_name: str, inputs=None, input_list=None):
-    input_list_file = None
-    input_files = []
-
-    # Prepare input list
-    if input_list is not None:
-        input_list_file = f"{dest_path}/{file_name}"
-        with open(input_list_file, "w") as f:
-            f.write(input_list)
-            f.flush()
-
-    # Prepare input data
-    if inputs is not None:
-        for idx, data in enumerate(inputs):
-            for i, d in enumerate(data):
-                file_name = f"{dest_path}/input_{idx}_{i}.raw"
-                if not isinstance(d, torch.Tensor):
-                    d = torch.tensor(d)
-                d.detach().numpy().tofile(file_name)
-                input_files.append(file_name)
-
-    return input_list_file, input_files
-
 if __name__ == "__main__":
     # Argument parser for dynamic inputs
     parser = argparse.ArgumentParser(description="Export models with executorch.")
-    parser.add_argument("--suite", type=str, required=True, choices=["timm", "torchvision", "huggingface"],
-                        help="Select the model suite (timm, torchvision, huggingface).")
+    parser.add_argument(
+        "--suite",
+        type=str,
+        required=True,
+        choices=["timm", "torchvision", "huggingface"],
+        help="Select the model suite (timm, torchvision, huggingface).",
+    )
     parser.add_argument("--model", type=str, required=True, help="Model name to be loaded.")
-    parser.add_argument("--input_shape", type=eval, required=True,
-                        help="Input shape for the model as a list or tuple (e.g., [1, 3, 224, 224] or (1, 3, 224, 224)).")
+    parser.add_argument(
+        "--input_shape",
+        type=eval,
+        required=True,
+        help="Input shape for the model as a list or tuple (e.g., [1, 3, 224, 224] or (1, 3, 224, 224)).",
+    )
     parser.add_argument("--quantize", action="store_true", help="Enable model quantization.")
     parser.add_argument("--dataset", type=str, help="Path to the calibration dataset.")
-    parser.add_argument("--device", type=str, default="CPU",
-                        help="Target device for compiling the model (e.g., CPU, GPU). Default is CPU.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="CPU",
+        help="Target device for compiling the model (e.g., CPU, GPU). Default is CPU.",
+    )
 
     args = parser.parse_args()
 

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -231,7 +231,7 @@ def main(
             raise ValueError(msg)
 
         if not dataset_path:
-            msg = "Validateion requires a calibration dataset."
+            msg = "Validation requires a calibration dataset."
             raise ValueError(msg)
 
         print("Start validation of the model:")
@@ -266,7 +266,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--validate",
         action="store_true",
-        help="Enable model validation. --dataset argument is requred for the validation.",
+        help="Enable model validation. --dataset argument is required for the validation.",
     )
     parser.add_argument("--dataset", type=str, help="Path to the validation dataset.")
     parser.add_argument(

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -30,8 +30,6 @@ from torch.fx.passes.graph_drawer import FxGraphDrawer
 from transformers import AutoModel
 
 import nncf
-import nncf.experimental
-import nncf.experimental.torch
 from nncf.experimental.torch.fx.quantization.quantize_pt2e import quantize_pt2e
 
 
@@ -239,7 +237,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Enable model validation. --dataset argument is requred for the validation.",
     )
-    parser.add_argument("--dataset", type=str, help="Path to the calibration dataset.")
+    parser.add_argument("--dataset", type=str, help="Path to the validation dataset.")
     parser.add_argument(
         "--device",
         type=str,

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -135,9 +135,12 @@ def main(
         def transform(x):
             return x[0]
 
+        default_subset_size = 300
+        batch_size = calibration_dataset.batch_size
         quantized_model = quantize_pt2e(
             captured_model,
             quantizer,
+            subset_size=(default_subset_size // batch_size) + int(default_subset_size % batch_size > 0),
             calibration_dataset=nncf.Dataset(calibration_dataset, transform_func=transform),
             fold_quantize=False,
         )

--- a/examples/openvino/aot/aot_openvino_compiler.py
+++ b/examples/openvino/aot/aot_openvino_compiler.py
@@ -29,7 +29,6 @@ from torch.ao.quantization.quantize_pt2e import convert_pt2e
 from torch.ao.quantization.quantize_pt2e import prepare_pt2e
 from torch.export import export
 from torch.export.exported_program import ExportedProgram
-from torch.fx.passes.graph_drawer import FxGraphDrawer
 from transformers import AutoModel
 
 import nncf
@@ -70,11 +69,6 @@ def load_calibration_dataset(dataset_path: str, batch_size: int, suite: str, mod
     )
 
     return calibration_dataset
-
-
-def visualize_fx_model(model: torch.fx.GraphModule, output_svg_path: str):
-    g = FxGraphDrawer(model, output_svg_path)
-    g.get_dot_graph().write_svg(output_svg_path)
 
 
 def dump_inputs(calibration_dataset, dest_path):
@@ -204,7 +198,6 @@ def main(
         quantized_model = quantize_model(
             aten_dialect.module(), calibration_dataset, use_nncf=quantization_flow == "nncf"
         )
-        visualize_fx_model(quantized_model, f"{model_name}_int8.svg")
 
         aten_dialect: ExportedProgram = export(quantized_model, example_args)
 

--- a/examples/openvino/executor_runner/openvino_executor_runner.cpp
+++ b/examples/openvino/executor_runner/openvino_executor_runner.cpp
@@ -179,6 +179,7 @@ int main(int argc, char** argv) {
       std::string file_path;
       while (std::getline(input_list, file_path)) {
         auto input_files = split(file_path, " ");
+        ET_LOG(Info, "INPUT_FILES.SIZE: %ld", input_files.size());
         if (input_files.size() == 0) {
           break;
         }

--- a/examples/openvino/executor_runner/openvino_executor_runner.cpp
+++ b/examples/openvino/executor_runner/openvino_executor_runner.cpp
@@ -180,6 +180,7 @@ int main(int argc, char** argv) {
       while (std::getline(input_list, file_path)) {
         auto input_files = split(file_path, " ");
         ET_LOG(Info, "INPUT_FILES.SIZE: %ld", input_files.size());
+        ET_LOG(Info, "NUM_INPUTS: %ld", num_inputs);
         if (input_files.size() == 0) {
           break;
         }
@@ -189,6 +190,7 @@ int main(int argc, char** argv) {
                 method_meta.input_tensor_meta(input_index);
             auto input_data_ptr = inputs[input_index].toTensor().data_ptr<char>();
 
+            ET_LOG(Info, "READ FILE %s", std::string(input_files[input_index]));
             std::ifstream fin(input_files[input_index], std::ios::binary);
             fin.seekg(0, fin.end);
             size_t file_size = fin.tellg();

--- a/examples/openvino/executor_runner/openvino_executor_runner.cpp
+++ b/examples/openvino/executor_runner/openvino_executor_runner.cpp
@@ -82,7 +82,6 @@ void dump_outputs(Result<Method> &method, const char *output_folder_path,
     std::ofstream fout(output_file_name.c_str(), std::ios::binary);
     fout.write(output_tensor.const_data_ptr<char>(), output_tensor.nbytes());
     fout.close();
-    ET_LOG(Info, "Write outputs to file %s", output_file_name.c_str());
   }
 }
 
@@ -135,8 +134,6 @@ ProcessInputsResult process_inputs(Result<Method> &method,
             method_meta.input_tensor_meta(input_index);
         auto input_data_ptr = inputs[input_index].toTensor().data_ptr<char>();
 
-        ET_LOG(Info, "Read inputs from file %s",
-               input_files[input_index].c_str());
         std::ifstream fin(input_files[input_index], std::ios::binary);
         fin.seekg(0, fin.end);
         size_t file_size = fin.tellg();

--- a/examples/openvino/openvino_build_example.sh
+++ b/examples/openvino/openvino_build_example.sh
@@ -34,7 +34,6 @@ main() {
     local example_dir=examples/openvino
     local example_build_dir="${build_dir}/${example_dir}"
     local cmake_prefix_path="${PWD}/${build_dir}/lib/cmake/ExecuTorch;${PWD}/${build_dir}/third-party/gflags;"
-
     rm -rf "${example_build_dir}"
 
     ## OpenVINO original
@@ -43,11 +42,10 @@ main() {
           -B"${example_build_dir}" \
           $EXECUTORCH_ROOT/$example_dir
 
+<<<<<<< HEAD:examples/openvino/openvino_build_example.sh
     cmake --build "${example_build_dir}" -j$(nproc)
-
-    # Switch back to the original directory
-    cd - > /dev/null
-
+=======
+    cmake --build "${example_build_dir}" -j5
     # Print a success message
     echo "Build successfully completed."
 }

--- a/examples/openvino/openvino_build_example.sh
+++ b/examples/openvino/openvino_build_example.sh
@@ -42,10 +42,11 @@ main() {
           -B"${example_build_dir}" \
           $EXECUTORCH_ROOT/$example_dir
 
-<<<<<<< HEAD:examples/openvino/openvino_build_example.sh
     cmake --build "${example_build_dir}" -j$(nproc)
-=======
-    cmake --build "${example_build_dir}" -j5
+
+    # Switch back to the original directory
+    cd - > /dev/null
+
     # Print a success message
     echo "Build successfully completed."
 }

--- a/examples/openvino/openvino_build_example.sh
+++ b/examples/openvino/openvino_build_example.sh
@@ -34,6 +34,7 @@ main() {
     local example_dir=examples/openvino
     local example_build_dir="${build_dir}/${example_dir}"
     local cmake_prefix_path="${PWD}/${build_dir}/lib/cmake/ExecuTorch;${PWD}/${build_dir}/third-party/gflags;"
+
     rm -rf "${example_build_dir}"
 
     ## OpenVINO original


### PR DESCRIPTION
### Summary
* OpenVINOQuantizer is introduced 
* `aot_openvino_compiler.py` is updated with the quantization pipeline (timm and torchvision backends only)
* `openvino_executor_runner.cpp` is updated to take several inputs / produce several outputs in a row. This allows to validate models converted to the edge (inspired by the [qualcom example](https://github.com/pytorch/executorch/blob/main/examples/qualcomm/scripts/mobilenet_v3.py#L64-L75)) (code style is refactored by clang-format)
* `aot_openvino_compiler.py` is updated with a validation pipeline (timm and torchvision backends only)

### Test plan

Model | FP32 acc | INT8 acc | FP32 avg latency | INT8 avg latency | Batch size
-- | -- | -- | -- | -- | --
Resnet50d | 0.80534 | 0.8038 | 538 | 178.167 | 125
