### PR TITLE
[OpenVINOBackend] Update NNCF version

### DIFF
--- a/backends/openvino/requirements.txt
+++ b/backends/openvino/requirements.txt
@@ -1,2 +1,2 @@
 transformers
-git+https://github.com/openvinotoolkit/nncf@191b53d#egg=nncf
+git+https://github.com/openvinotoolkit/nncf@6b0fc1c#egg=nncf


### PR DESCRIPTION
### Summary
To fix

```
  File "/home/devuser/dlyakhov/executorch/env/lib/python3.10/site-packages/executorch/backends/openvino/quantizer/quantizer.py", line 375, in quantize_model
    quantized_model = nncf_fx.quantize_pt2e(
AttributeError: module 'nncf.experimental.torch.fx' has no attribute 'quantize_pt2e'
```