### PR TITLE
Temporarily Fix for Quantizer Import Issue

### DIFF
--- a/backends/openvino/__init__.py
+++ b/backends/openvino/__init__.py
@@ -1,5 +1,4 @@
 from .partitioner import OpenvinoPartitioner
 from .preprocess import OpenvinoBackend
-from .quantizer.quantizer import OpenVINOQuantizer
 
-__all__ = [OpenvinoBackend, OpenvinoPartitioner, OpenVINOQuantizer]
+__all__ = [OpenvinoBackend, OpenvinoPartitioner]


### PR DESCRIPTION
Importing OpenVINOQuantizer requires users to use `nncf.torch.disable_patching`  even if they do not use the quantizer. Removing this import from __init__.py for now until we find a better solution. For the time being, OpenVINOQuantizer should be imported explicitly to use the quantizer.
