### PR TITLE
Fixed typechecker issues

### DIFF
--- a/backends/openvino/partitioner.py
+++ b/backends/openvino/partitioner.py
@@ -4,6 +4,8 @@
 # except in compliance with the License. See the license file found in the
 # LICENSE file in the root directory of this source tree.
 
+# mypy: disable-error-code=import-not-found
+
 from typing import Callable, final, List, Optional, Tuple
 
 import torch

--- a/backends/openvino/preprocess.py
+++ b/backends/openvino/preprocess.py
@@ -4,6 +4,8 @@
 # except in compliance with the License. See the license file found in the
 # LICENSE file in the root directory of this source tree.
 
+# mypy: disable-error-code=import-not-found
+
 from typing import final, List
 
 from executorch.exir.backend.backend_details import (

--- a/backends/openvino/quantizer/quantizer.py
+++ b/backends/openvino/quantizer/quantizer.py
@@ -4,6 +4,8 @@
 # except in compliance with the License. See the license file found in the
 # LICENSE file in the root directory of this source tree.
 
+# mypy: disable-error-code=import-not-found
+
 from collections import defaultdict
 from enum import Enum
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Type

--- a/backends/openvino/tests/test_runner.py
+++ b/backends/openvino/tests/test_runner.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-import nncf.torch  # type: ignore[import-untyped]
+import nncf.torch  # type: ignore[import-untyped,import-not-found]
 
 
 class OpenvinoTestSuite(unittest.TestSuite):

--- a/examples/openvino/aot_optimize_and_infer.py
+++ b/examples/openvino/aot_optimize_and_infer.py
@@ -4,7 +4,7 @@
 # except in compliance with the License. See the license file found in the
 # LICENSE file in the root directory of this source tree.
 
-# mypy: disable-error-code=import-untyped
+# mypy: disable-error-code="import-untyped,import-not-found"
 
 import argparse
 import time


### PR DESCRIPTION
### Summary
Fixed import-not-found errors. These are because we don't have openvino and nncf packages installed at the time of linter checks.
Added ignores for these
